### PR TITLE
REDDEV-560 implement consort report

### DIFF
--- a/js/components/ConsortReport.vue
+++ b/js/components/ConsortReport.vue
@@ -29,10 +29,6 @@ export default {
   name: 'ConsortReport',
   inject: ['dataService'],
 
-  props: {
-    pid: Number
-  },
-
   components: {
     ReportCount
   },

--- a/js/components/ConsortReport.vue
+++ b/js/components/ConsortReport.vue
@@ -1,39 +1,99 @@
 <template>
-  <div class="container">
-    Hello World From Vue
+  <div id="consort-report-container" class="container" v-if="!loading">
+      <div class="error" v-if="hasError">
+        {{ errorMessage }}
+        <ul v-if="hasErrorDetails">
+          <li v-for="message in errorDetails" :key="message">{{ message }}</li>
+        </ul>
+      </div>
+
+      <ReportCount v-for="report in reportConfig"
+                   :report-name="report.name"
+                   :report-id="report.reportId" />
   </div>
 </template>
 
 <script>
+import ReportCount from './ReportCount';
+
+const messages = {
+  warnings: {
+    configError: 'Report configuration could not be loaded due to an error: '
+  }
+};
+
 /**
  * ConsortReport root component.
  */
 export default {
   name: 'ConsortReport',
+  inject: ['dataService'],
 
   props: {
     pid: Number
   },
 
   components: {
+    ReportCount
   },
 
   data() {
     return {
-      config: {},
+      reportConfig: {},
       loading: true
     };
   },
 
   mounted() {
     // capture the promise to synchronize tests
-    this.configPromise = this.fetchConfig();
+    this.configPromise = this.fetchReportConfig();
   },
 
   methods: {
+    /**
+     * Get report configuration
+     */
+    fetchReportConfig() {
+      const { dataService } = this;
+      return dataService.getReportConfig()
+        .then(this.captureReportConfig)
+        .catch(this.handleConfigError)
+        .finally(() => {
+          this.loading = false;
+        });
+    },
+
+    /**
+     * Sets report configuration from `fetchReportConfig` response.
+     * @param {Promise->Object[]} responseArray - `dataService.getReportConfig` response
+     * @see fetchReportConfig
+     * @see data-service.js
+     */
+    captureReportConfig(responseArray) {
+      const { reportConfig } = responseArray;
+      this.reportConfig = reportConfig;
+    },
+
+    /**
+     * Handles rejection of the `fetchReportConfig` request.
+     * @param {Error} reason - the error that triggered rejection.
+     */
+    handleConfigError(reason) {
+      this.errorMessage = messages.warnings.reportConfigError;
+      this.errorDetails = [ reason.message ];
+    },
   },
 
   computed: {
+    hasError() {
+      const { errorMessage } = this;
+      return Boolean(errorMessage);
+    },
+
+    hasErrorDetails() {
+      const { errorDetails } = this;
+      return Array.isArray(errorDetails) && errorDetails.length > 0;
+    }
   }
 }
 </script>

--- a/js/components/ReportCount.vue
+++ b/js/components/ReportCount.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="container">
+    <h3>{{ reportName}}</h3>
+    <p>{{ count }}</p>
+  </div>
+</template>
+
+<script>
+
+/**
+ * Renders count for report
+ */
+export default {
+  name: 'ReportCount',
+  inject: ['dataService'],
+
+  props: {
+    reportName: String,
+    reportId: Number
+  },
+
+  data() {
+    return {
+      count: null
+    }
+  },
+
+  mounted() {
+    // capture the promise to synchronize tests
+    this.configPromise = this.fetchReportCount();
+  },
+
+  methods: {
+    /**
+     * Get report configuration
+     */
+    fetchReportCount() {
+      const { dataService, reportId } = this;
+      return dataService.getReportCount(reportId)
+        .then(this.captureReportCount);
+    },
+
+    /**
+     * Capture count for report.
+     * @param {Promise->Object[]} responseObject - `dataService.getReportCount` response
+     * @see fetchReportCount
+     * @see data-service.js
+     */
+    captureReportCount(responseObject) {
+      const { count } = responseObject;
+      this.count = count;
+    }
+  }
+}
+</script>

--- a/js/components/ReportCount.vue
+++ b/js/components/ReportCount.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <h3>{{ reportName}}</h3>
+    <h3>{{ reportName }}</h3>
     <p>{{ count }}</p>
   </div>
 </template>

--- a/js/main.js
+++ b/js/main.js
@@ -3,12 +3,15 @@ import 'babel-polyfill';
 import Vue from 'vue';
 
 import ConsortReport from './components/ConsortReport';
+import createDataService from './services/data-service';
 
 /**
  * Main method that will render a consort diagram.
  */
 export function run(urlsJsonString) {
   const urls = JSON.parse(urlsJsonString);
+  const dataService = createDataService(urls);
+
   new Vue({
     el: '.consort-report-container',
     components: { ConsortReport },
@@ -24,7 +27,8 @@ export function run(urlsJsonString) {
     },
     provide() {
       return {
-        urls
+        urls,
+        dataService
       };
     }
   });

--- a/js/main.js
+++ b/js/main.js
@@ -16,14 +16,7 @@ export function run(urlsJsonString) {
     el: '.consort-report-container',
     components: { ConsortReport },
     render(createElement) {
-      return createElement(ConsortReport, {
-        props: {
-          pid: this.pid
-        }
-      });
-    },
-    data: {
-      pid
+      return createElement(ConsortReport, { });
     },
     provide() {
       return {

--- a/js/services/data-service.js
+++ b/js/services/data-service.js
@@ -1,0 +1,67 @@
+import assert from 'assert';
+import axios from 'axios';
+import qs from 'qs';
+
+export const ENDPOINTS = {
+  REPORT_DATA: 'lib/data.php',
+  REPORT_CONFIG: 'lib/settings.php'
+};
+
+/**
+ * Constructs a service that fetches data for the current project from REDCap.
+ *
+ * @param {Object} assetUrls - key/value pairs where the key is a relative file path
+ *   like `lib/data.php`, and the value is the corresponding external module URL
+ *   like `http://localhost/redcap/api/?type=module&prefix=consort-report&page=lib%2Fdata&pid=42`
+ * @return {Object} an object encapsulating REDCap HTTP requests
+ */
+export default function createDataService(assetUrls) {
+  assert(assetUrls, 'Asset URL object is required');
+  Object.keys(ENDPOINTS).forEach(key => {
+    const endpoint = ENDPOINTS[key];
+    assert(assetUrls[endpoint], `A URL for ${endpoint} is required`)
+  });
+
+  return {
+    reportConfigUrl: assetUrls[ENDPOINTS.REPORT_CONFIG],
+    reportDataUrl: assetUrls[ENDPOINTS.REPORT_DATA],
+
+    /**
+     * Extracts data returned by the request.
+     * @param {Promise->Object} response - an axios response object.
+     * @return {Promise->Object} the response's data
+     * @private
+     */
+    _extractData(response) {
+      return response.data;
+    },
+
+    /**
+     * Get the current report configuration.
+     *
+     * @return {Promise ->{report-config: Object[]}} - Returns a promise that resolves to an array of report configurations.
+     */
+    getReportConfig() {
+      return axios(this.reportConfigUrl)
+        .then(this._extractData)
+        .then(data => {
+          const reportConfigArray = data;
+          const emptyConfig = Boolean(reportConfigArray && reportConfigArray.length < 1);
+          let reportConfig = emptyConfig ? [] : reportConfigArray;
+          return { reportConfig };
+        });
+    },
+
+    /**
+     * Gets total number of records for report.
+     *
+     * @param {Number} reportId - the report id.
+     * @return {Promise} A promise that resolves to an object with the following keys:
+     *   - count: The total number of records for a report.
+     */
+    getReportCount(reportId) {
+      return axios.post(this.reportDataUrl, qs.stringify({ reportId: reportId }))
+        .then(this._extractData);
+    },
+  };
+}


### PR DESCRIPTION
This introduces the previous behavior of displaying the total count of records for each configured report.

I'm working on resolving unit tests at the moment, and I'm also going to look at loading all of the data in one request instead of a call per report but I'll probably submit that in another PR. As it currently stands, occasionally a report fails. I think the calls are too quick. In the old code the next report was requested only after the previous had returned successfully.

![screen shot 2018-09-04 at 13 43 36](https://user-images.githubusercontent.com/273863/45056719-8d539880-b048-11e8-9b61-e9f0421723c3.png)

