### PR TITLE
REDDEV-383 restructured to support itemized counts

### DIFF
--- a/js-tests/components/ConsortReport_test.js
+++ b/js-tests/components/ConsortReport_test.js
@@ -7,8 +7,8 @@ function createProvideObject() {
   return {
     assetUrls: {},
     dataService: {
-      getReportConfig() {
-        return Promise.resolve([{ "name": "Report Name", "reportId": 42 }]);
+      fetchReportSummary() {
+        return Promise.resolve([{ "title": "Report Name", "reportId": 42 }]);
       }
     }
   };
@@ -19,7 +19,7 @@ describe('ConsortReport.vue', () => {
 
   beforeEach((done) => {
     mockProvide = createProvideObject();
-    spyOn(mockProvide.dataService, 'getReportConfig').and.callThrough();
+    spyOn(mockProvide.dataService, 'fetchReportSummary').and.callThrough();
 
     wrapper = shallowMount(ConsortReport, {
       provide: mockProvide
@@ -28,8 +28,8 @@ describe('ConsortReport.vue', () => {
     wrapper.vm.configPromise.then(() => done());
   });
 
-  it('requests report config when mounted', () => {
+  it('requests report summary when mounted', () => {
     const { dataService } = mockProvide;
-    expect(dataService.getReportConfig).toHaveBeenCalled();
+    expect(dataService.fetchReportSummary).toHaveBeenCalled();
   });
 });

--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -9,7 +9,7 @@ describe('ReportSummary.vue', () => {
   beforeEach(() => {
     wrapper = shallowMount(ReportSummary, {
       propsData: {
-        reportName: 'Sample Report Name',
+        title: 'Sample Report Name',
         totalRecords: 101
       }
     });
@@ -17,9 +17,6 @@ describe('ReportSummary.vue', () => {
 
   it('renders report summary', () => {
     const reportName = wrapper.find('h3');
-    expect(reportName.text()).toBe('Sample Report Name');
-
-    const totalRecords = wrapper.find('p');
-    expect(totalRecords.text()).toBe('101');
+    expect(reportName.text()).toBe('101 - Sample Report Name');
   });
 });

--- a/js/components/ConsortReport.vue
+++ b/js/components/ConsortReport.vue
@@ -12,7 +12,7 @@
     </div>
     <div v-if="!loading">
       <ReportSummary v-for="summary in reportSummaries"
-                    :report-name="summary.name"
+                    :title="summary.title"
                     :total-records="summary.totalRecords" />
     </div>
   </div>
@@ -57,9 +57,7 @@ export default {
      */
     fetchReportConfig() {
       const { dataService } = this;
-      return dataService.getReportConfig()
-        .then(this.captureReportConfig)
-        .then(this.fetchReportSummary)
+      return dataService.fetchReportSummary()
         .then(this.captureReportSummaries)
         .catch(this.handleConfigError)
         .finally(() => {
@@ -68,23 +66,11 @@ export default {
     },
 
     /**
-     * Sets report configuration from `fetchReportConfig` response.
-     * @param {Promise->Object[]} responseArray - `dataService.getReportConfig` response
-     * @see fetchReportConfig
-     * @see data-service.js
-     */
-    captureReportConfig(responseArray) {
-      const { reportConfig } = responseArray;
-      this.reportConfig = reportConfig;
-    },
-
-    /**
-     * Get a report summary for the provided report ids.
+     * Get a report summary.
      */
     fetchReportSummary() {
       const { dataService } = this;
-      const reportIds = this.reportConfig.map(report => report.reportId);
-      return dataService.fetchReportSummary(reportIds);
+      return dataService.fetchReportSummary();
     },
 
     /**
@@ -93,9 +79,6 @@ export default {
      */
     captureReportSummaries(responseArray) {
       this.reportSummaries = responseArray;
-      this.reportSummaries.map(summary => {
-        summary.name = this.reportConfig.find(report => report.reportId === summary.reportId).name;
-      });
     },
 
     /**

--- a/js/components/ConsortReport.vue
+++ b/js/components/ConsortReport.vue
@@ -40,7 +40,6 @@ export default {
 
   data() {
     return {
-      reportConfig: {},
       reportSummaries: [],
       loading: true
     };
@@ -48,14 +47,14 @@ export default {
 
   mounted() {
     // capture the promise to synchronize tests
-    this.configPromise = this.fetchReportConfig();
+    this.configPromise = this.fetchReportSummary();
   },
 
   methods: {
     /**
-     * Get report configuration
+     * Get a report summary.
      */
-    fetchReportConfig() {
+    fetchReportSummary() {
       const { dataService } = this;
       return dataService.fetchReportSummary()
         .then(this.captureReportSummaries)
@@ -63,14 +62,6 @@ export default {
         .finally(() => {
           this.loading = false;
         });
-    },
-
-    /**
-     * Get a report summary.
-     */
-    fetchReportSummary() {
-      const { dataService } = this;
-      return dataService.fetchReportSummary();
     },
 
     /**

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="container">
-    <h3>{{ reportName }}</h3>
-    <p>{{ totalRecords }}</p>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <div class="container">
+        <h3>{{ totalRecords }} - {{ title }}</h3>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -14,7 +17,7 @@ export default {
   name: 'ReportSummary',
 
   props: {
-    reportName: String,
+    title: String,
     totalRecords: Number
   }
 }

--- a/js/services/data-service.js
+++ b/js/services/data-service.js
@@ -23,7 +23,6 @@ export default function createDataService(assetUrls) {
   });
 
   return {
-    reportConfigUrl: assetUrls[ENDPOINTS.REPORT_CONFIG],
     reportDataUrl: assetUrls[ENDPOINTS.REPORT_DATA],
 
     /**
@@ -37,30 +36,14 @@ export default function createDataService(assetUrls) {
     },
 
     /**
-     * Get the current report configuration.
-     *
-     * @return {Promise ->{report-config: Object[]}} - Returns a promise that resolves to an array of report configurations.
-     */
-    getReportConfig() {
-      return axios(this.reportConfigUrl)
-        .then(this._extractData)
-        .then(data => {
-          const reportConfigArray = data;
-          const emptyConfig = Boolean(reportConfigArray && reportConfigArray.length < 1);
-          return { reportConfig: emptyConfig ? [] : reportConfigArray };
-        });
-    },
-
-    /**
      * Get a report summary that includes the total number of records for a report.
      *
-     * @param {Number} reportId - the report id.
      * @return {Promise} A promise that resolves to an object with the following keys:
-     *   - count: The total number of records for a report.
+     *   - reportId: The report ID.
+     *   - totalRecords: The total number of records for a report.
      */
-    fetchReportSummary(reportIds) {
-      return axios.post(this.reportDataUrl, qs.stringify({ reportIds: reportIds }))
-        .then(this._extractData);
+    fetchReportSummary() {
+      return axios.post(this.reportDataUrl).then(this._extractData);
     },
   };
 }

--- a/lib/data.php
+++ b/lib/data.php
@@ -10,22 +10,19 @@ header('Content-Type: application/json');
 
 // Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
 require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
+require_once(dirname(realpath(__FILE__)) . '/ReportConfig.php');
 
-/**
- * Filter the input
- */
-function filterInput($str) {
-  return filter_var($str, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
-}
+$reportConfigInstance = new \Octri\ConsortReport\ReportConfig($project_id, $module);
+$reportConfig = json_decode($reportConfigInstance->getReportConfig(), true);
 
 $returnArray = array();
-foreach ($_POST['reportIds'] as $reportId) {
-    $reportId = intval(filterInput($reportId));
-    $report = REDCap::getReport($reportId, 'json');
-    $returnArray[] = array(
-        'reportId' => $reportId,
-        'totalRecords' => count(json_decode($report, true))
-    );
+foreach ($reportConfig as $reportNode) {
+    $report = REDCap::getReport($reportNode['reportId'], 'json');
+    $returnArray[] = array_merge($reportNode, array(
+        'totalRecords' => count(json_decode($report, true)),
+        'data' => $report
+    ));
 }
+
 print json_encode($returnArray);
 ?>

--- a/lib/sample.report-config.json
+++ b/lib/sample.report-config.json
@@ -1,14 +1,18 @@
 [
   {
-    "name": "Enrolled",
-    "reportId": 9080
+    "reportId": 10908,
+    "title": "Eligible and enrolled in placebo adherence run-in (Enrolled/Consented)",
+    "strategy": "total"
   },
   {
-    "name": "Discontinued Prior to Randomization",
-    "reportId": 9082
+    "reportId": 10909,
+    "title": "Excluded (Discontinued)",
+    "strategy": "itemized",
+    "bucket-by": "dsp_stop_reason"
   },
   {
-    "name": "Randomized",
-    "reportId": 9081
+    "reportId": 10910,
+    "title": "Pregnant smokers randomized (Randomized)",
+    "strategy": "total"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7287,7 +7287,7 @@
     "qjobs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
-      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
+      "integrity": "sha1-xF6cYYAL0IfviNfiVkI73Unl0HE=",
       "dev": true
     },
     "qs": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,8 @@ module.exports = {
       'index.php',
       'ConsortReport.php',
       'config.json',
-      'lib/**/*.php'
+      'lib/**/*.php',
+      'lib/**/*.json'
     ]),
     new HtmlWebpackPlugin({
       template: 'lib/main.tmpl',


### PR DESCRIPTION
Restructured configuration to support itemized counts.

Below is a screenshot that shows a part of the consort diagram for the three reports currently being processed. Initially I think we can iterate through the configuration array and depending on the strategy, display a total count, or an itemized count. `bucket-by` is the field for bucketing the itemized counts. The values of this field are the bucket labels shown in the diagram. I think the bucketing can happen on the front-end, but depending on the report sizes it may need to be processed on the server, I'm not sure yet. For these three reports, the response was 6.9kb.

![screen shot 2018-09-05 at 11 51 53](https://user-images.githubusercontent.com/273863/45121634-914dec00-b116-11e8-8bd6-8d737908ccf6.png)