### PR TITLE
REDDEV-383 updates for bootstrap 4

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,10 @@
       "institution": "OHSU"
     }
   ],
+  "compatibility": {
+      "redcap-version-min": "8.7.1",
+      "redcap-version-max": ""
+  },
   "permissions": [
     "select_data"
   ],

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="panel panel-default">
-    <div class="panel-body">
+  <div class="panel panel-default card mb-3">
+    <div class="panel-body card-body">
       <div class="container">
-        <h3>{{ totalRecords }} - {{ title }}</h3>
+        <h3 class="card-title">{{ totalRecords }} - {{ title }}</h3>
 
         <ul v-if="isItemized" class="list-unstyled">
           <li v-for="(count, label) in summaryCounts" :key="label">{{ count }} - {{ label }}</li>

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="panel panel-default card mb-3">
-    <div class="panel-body card-body">
+  <div class="card mb-3">
+    <div class="card-body">
       <div class="container">
         <h3 class="card-title">{{ totalRecords }} - {{ title }}</h3>
 


### PR DESCRIPTION
After deploying to dev I needed to update some styles for Bootstrap 4. I took a similar approach to what Matt did. This should work on both BS 3 and 4 now. `mb-3` adds a bit of margin below cards since they default to no margins.