### PR TITLE
2. REDDEV-510 add ReportSummaryForm

### DIFF
--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="card mb-3 report-summary-form">
+    <div class="card-body">
+      <h5 class="card-title">Add a Report Count</h5>
+      <div class="form-group">
+        <label>Title <input id="title" name="title" v-model="title" type="text" class="form-control"></label>
+      </div>
+      <div class="form-group">
+        <label>Report
+          <select id="reportId" name="reportId" v-model="reportId" class="form-control">
+            <option v-for="report in reports" :value="report.reportId">{{ report.title }}</option>
+          </select>
+        </label>
+      </div>
+      <button type="submit" class="btn btn-primary" @click="saveReportSummary">Submit</button>
+      <a class="btn btn-link cancel" @click="cancelForm">Reset</a>
+    </div>
+  </div>
+</template>
+
+<script>
+/**
+ * Renders report summary form for adding report counts.
+ */
+export default {
+  name: 'ReportSummaryForm',
+  inject: ['dataService'],
+
+  data() {
+    return {
+      title: '',
+      reportId: null,
+      reports: []
+    };
+  },
+
+  mounted() {
+    // capture the promise to synchronize tests
+    this.reportPromise = this.fetchReports();
+  },
+
+  methods: {
+    /**
+     * Signal a new report is being built.
+     */
+    fetchReports() {
+      const { dataService } = this;
+      return dataService.getReports()
+        .then(this.captureReports)
+        .catch(this.handleConfigError);
+    },
+
+    /**
+     * Sets reports array from `getReports` response.
+     * @param {Promise->Object[]} responseArray - `dataService.getReports` response
+     */
+    captureReports(responseArray) {
+      this.reports = responseArray;
+    },
+
+    /**
+     * Clears current form values.
+     */
+    clearForm() {
+      this.title = '';
+      this.reportId = null;
+    },
+
+    /**
+     * Currently canceling the ReportSummaryForm just clears the fields.
+     * TODO: May close the form eventually, but currently clears the form until we better understand the UI.
+     */
+    cancelForm() {
+      this.clearForm();
+    },
+
+    /**
+     * Returns the model attributes to be saved to report config.
+     */
+    reportSummary() {
+      return {
+        reportId: this.reportId,
+        title: this.title,
+        strategy: 'total'
+      };
+    },
+
+    /**
+     * Save report config and clear form.
+     */
+    saveReportSummary() {
+      const { dataService } = this;
+      this.savePromise = dataService.saveReportSummary(this.reportSummary())
+        .then(this.captureReportSummary)
+        .catch(this.handleConfigError)
+        .finally(this.clearForm);
+    },
+
+    /**
+     * Sets report summary from `fetchReportSummary` response. This response is
+     * emitted and processed by ConsortReport.
+     * @param {Promise->Object[]} responseArray - `dataService.fetchReportSummary` response
+     */
+    captureReportSummary(responseArray) {
+      this.$emit('reportSummary', responseArray[0]);
+    },
+  }
+}
+</script>

--- a/js/services/data-service.js
+++ b/js/services/data-service.js
@@ -24,6 +24,7 @@ export default function createDataService(assetUrls) {
 
   return {
     reportDataUrl: assetUrls[ENDPOINTS.REPORT_DATA],
+    reportConfigUrl: assetUrls[ENDPOINTS.REPORT_CONFIG],
 
     /**
      * Extracts data returned by the request.
@@ -45,5 +46,24 @@ export default function createDataService(assetUrls) {
     fetchReportSummary() {
       return axios.post(this.reportDataUrl).then(this._extractData);
     },
+
+    /**
+     * Post report summary for saving to report config.
+     * @param {Object} reportSummary Data for a report summary.
+     * @return {Promise->Object} the response's report summary data
+     */
+    saveReportSummary(reportSummary) {
+      const data = { reportSummary: JSON.stringify({ reportSummary }) };
+      const options = { timeout: 5000 };
+      return axios.post(this.reportConfigUrl + '&action=saveReportSummary', data, options).then(this._extractData);
+    },
+
+    /**
+     * Get all of the reports for the project.
+     * @return {Promise->Object} list of reports.
+     */
+    getReports() {
+      return axios.post(this.reportDataUrl + '&action=getReports').then(this._extractData);
+    }
   };
 }

--- a/lib/data.php
+++ b/lib/data.php
@@ -1,9 +1,10 @@
 <?php
 /**
  * MODULE: REDCap Consort Report
- * DESCRIPTION: Returns a report in the requested format.
- * RETURNS: Returns report count in JSON format.
- * Example: { "count": 42 }
+ * DESCRIPTION: Controller for handling REDCap data. Pass $_GET['action'] or
+ *              nothing for default.
+ * RETURNS: Default is to return report configuration. If action=getReports
+ *          then a list of reports for the project will be returned.
  */
 namespace Octri\ConsortReport;
 
@@ -14,15 +15,40 @@ require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 require_once(dirname(realpath(__FILE__)) . '/ReportConfig.php');
 require_once(dirname(realpath(__FILE__)) . '/ReportConfigProcessor.php');
 
-$reportConfigInstance = new ReportConfig($project_id, $module);
-$reportConfig = json_decode($reportConfigInstance->getReportConfig(), true);
+if (isset($_GET['action'])) {
+    if ($_GET['action'] === 'getReports') {
+        $pid = intval($_GET['pid']);
 
-$returnArray = array();
-foreach ($reportConfig as $summaryConfig) {
-    $report = json_decode(\REDCap::getReport($summaryConfig['reportId'], 'json', 'export', true /* export labels */), true);
-    $reportProcessor = new ReportConfigProcessor($report, $summaryConfig);
-    $returnArray[] = $reportProcessor->summaryConfig();
+        $stmt = mysqli_stmt_init($rc_connection);
+        $query = 'select report_id, title from redcap_reports where project_id = ?';
+        mysqli_stmt_prepare($stmt, $query);
+        mysqli_stmt_bind_param($stmt, 'i', $pid);
+        mysqli_stmt_execute($stmt);
+        mysqli_stmt_bind_result($stmt, $report_id, $title);
+        $returnArray = array();
+        while (mysqli_stmt_fetch($stmt)) {
+            $returnArray[] = array('reportId' => $report_id, 'title' => $title);
+        }
+        mysqli_stmt_close($stmt);
+
+        exit(json_encode($returnArray));
+    }
+} else {
+    $reportConfigInstance = new ReportConfig($project_id, $module);
+    $config = $reportConfigInstance->getReportConfig();
+
+    if (!$config) {
+        exit(json_encode(array()));
+    }
+
+    // Default action, get report config
+    $returnArray = array();
+    foreach ($config as $summaryConfig) {
+        $report = json_decode(\REDCap::getReport($summaryConfig['reportId'], 'json', 'export', true /* export labels */), true);
+        $reportProcessor = new ReportConfigProcessor($report, $summaryConfig);
+        $returnArray[] = $reportProcessor->summaryConfig();
+    }
+
+    exit(json_encode($returnArray));
 }
-
-print json_encode($returnArray);
 ?>

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -1,8 +1,11 @@
 <?php
 /**
  * MODULE: REDCap Consort Report
- * DESCRIPTION: Get project settings.
- * RETURNS: Returns project settings in JSON format.
+ * DESCRIPTION: Controller for handling report configuration. Pass
+ *              $_GET['action'] or nothing for default.
+ * RETURNS: Default returns project settings in JSON format. If
+ *          action=saveReportSummary the provided report summary will be
+ *          appended to the report configuration.
  */
 namespace Octri\ConsortReport;
 
@@ -11,8 +14,29 @@ header('Content-Type: application/json');
 // Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
 require_once(dirname(realpath(__FILE__)) . '/../../../redcap_connect.php');
 require_once(dirname(realpath(__FILE__)) . '/ReportConfig.php');
+require_once(dirname(realpath(__FILE__)) . '/ReportConfigProcessor.php');
 
-$reportConfig = new ReportConfig($project_id, $module);
-$settings = $reportConfig->getReportConfig();
+if (isset($_GET['action'])) {
+    if ($_GET['action'] === 'saveReportSummary') {
+        $requestBody = trim(file_get_contents('php://input'));
 
-print($settings);
+        if (!empty($requestBody)) {
+            $data = json_decode($requestBody, true);
+            $reportSummary = json_decode($data['reportSummary'], true);
+
+            $reportConfig = new ReportConfig($project_id, $module);
+            $reportConfig->saveReportSummary($reportSummary['reportSummary']);
+
+            $report = json_decode(\REDCap::getReport($reportSummary['reportSummary']['reportId'], 'json', 'export', true /* export labels */), true);
+            $reportProcessor = new ReportConfigProcessor($report, $reportSummary['reportSummary']);
+
+            exit(json_encode(array($reportProcessor->summaryConfig())));
+        }
+    }
+} else {
+    // Default action is to get report configuration.
+    $reportConfig = new ReportConfig($project_id, $module);
+    $settings = $reportConfig->getReportConfig();
+
+    print($settings);
+}


### PR DESCRIPTION
Add form for defining each report summary. Currently hard-coded
  to strategy=total.

  Report summaries are appended to the report configuration.

  Updated data.php and settings.php to support different actions.