### PR TITLE
REDDEV-510 Validate ReportSummary before saving

### DIFF
--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -129,7 +129,15 @@ export default {
      */
     captureReportSummary(responseArray) {
       this.$emit('reportSummary', responseArray[0]);
-    }
+    },
+
+    /**
+     * Handles rejection of the `saveReportSummary` request.
+     * @param {Error} reason - the error that triggered rejection.
+     */
+    handleConfigError(reason) {
+      this.errors.push('An error occurred while trying to save this count.');
+    },
   },
 
   computed: {

--- a/lib/ReportConfig.php
+++ b/lib/ReportConfig.php
@@ -75,10 +75,9 @@ class ReportConfig {
         $errors[] = 'Invalid strategy';
       } else {
         if ($reportSummary['strategy'] === ReportStrategy::ITEMIZED) {
-          if (array_key_exists('bucket-by', $reportSummary)) {
-            if (strlen(trim($reportSummary['bucket-by'])) === 0) {
-                $errors[] = "bucket-by must have a value";
-            }
+          if (array_key_exists('bucket-by', $reportSummary)
+              && strlen(trim($reportSummary['bucket-by'])) === 0) {
+            $errors[] = "bucket-by must have a value";
           } else {
             $errors[] = 'Missing bucket-by field when using strategy ' . ReportStrategy::ITEMIZED;
           }

--- a/lib/ReportStrategy.php
+++ b/lib/ReportStrategy.php
@@ -4,4 +4,8 @@ namespace Octri\ConsortReport;
 abstract class ReportStrategy {
     const TOTAL = 'total';
     const ITEMIZED = 'itemized';
+
+    public static function strategies() {
+        return array(self::TOTAL, self::ITEMIZED);
+    }
 }

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -22,12 +22,17 @@ if (isset($_GET['action'])) {
             $reportSummary = json_decode($data['reportSummary'], true);
 
             $reportConfig = new ReportConfig($project_id, $module);
-            $reportConfig->saveReportSummary($reportSummary['reportSummary']);
+            $result = $reportConfig->saveReportSummary($reportSummary['reportSummary']);
 
-            $report = json_decode(\REDCap::getReport($reportSummary['reportSummary']['reportId'], 'json', 'export', true /* export labels */), true);
-            $reportProcessor = new ReportConfigProcessor($report, $reportSummary['reportSummary']);
+            if ($result === true) {
+                $report = json_decode(\REDCap::getReport($reportSummary['reportSummary']['reportId'], 'json', 'export', true /* export labels */), true);
+                $reportProcessor = new ReportConfigProcessor($report, $reportSummary['reportSummary']);
 
-            exit(json_encode(array($reportProcessor->summaryConfig())));
+                exit(json_encode(array($reportProcessor->summaryConfig())));
+            } else {
+                http_response_code(400);
+                exit(json_encode($result));
+            }
         }
     }
 } else {

--- a/tests/ReportConfigTest.php
+++ b/tests/ReportConfigTest.php
@@ -65,4 +65,71 @@ final class ReportConfigTest extends TestCase {
     $this->assertEquals($config[2]['name'], 'Report 3');
   }
 
+  public function testValidate() {
+    $mockModule = $this->getMockBuilder(get_class(new MockAbstractExternalModule()))->getMock();
+    $reportConfig = new ReportConfig($this->projectIdWithConfigSet, $mockModule);
+
+    // Valid Report Summary
+    $reportSummary = array(
+        'reportId' => 42,
+        'title' => 'This is the title',
+        'strategy' => 'total'
+    );
+    $errors = $reportConfig->validate($reportSummary);
+    $this->assertTrue(count($errors) === 0, 'report summary should be valid');
+  }
+
+  public function testValidateStrategy() {
+    $mockModule = $this->getMockBuilder(get_class(new MockAbstractExternalModule()))->getMock();
+    $reportConfig = new ReportConfig($this->projectIdWithConfigSet, $mockModule);
+
+    $reportSummary = array(
+        'reportId' => 42,
+        'title' => 'This is the title',
+        'strategy' => 'notvalid'
+    );
+    $errors = $reportConfig->validate($reportSummary);
+    $this->assertTrue(in_array('Invalid strategy', $errors), 'validate should report invalid strategy');
+  }
+
+  public function testValidateMissingFieldAndReportId() {
+    $mockModule = $this->getMockBuilder(get_class(new MockAbstractExternalModule()))->getMock();
+    $reportConfig = new ReportConfig($this->projectIdWithConfigSet, $mockModule);
+
+    $reportSummary = array(
+        'reportId' => null,
+        'title' => 'This is the title'
+    );
+    $errors = $reportConfig->validate($reportSummary);
+    $this->assertTrue(in_array('Missing field strategy', $errors), 'validate should report missing field strategy');
+    $this->assertTrue(in_array('reportId must be an integer greater than zero', $errors), 'validate should report invalid reportId');
+  }
+
+  public function testValidateMissingBucketByField() {
+    $mockModule = $this->getMockBuilder(get_class(new MockAbstractExternalModule()))->getMock();
+    $reportConfig = new ReportConfig($this->projectIdWithConfigSet, $mockModule);
+
+    $reportSummary = array(
+        'reportId' => 42,
+        'title' => 'This is the title',
+        'strategy' => 'itemized'
+    );
+    $errors = $reportConfig->validate($reportSummary);
+    $this->assertTrue(in_array('Missing bucket-by field when using strategy itemized', $errors), 'validate should report missing field bucket-by');
+  }
+
+  public function testValidateMissingBucketByValue() {
+    $mockModule = $this->getMockBuilder(get_class(new MockAbstractExternalModule()))->getMock();
+    $reportConfig = new ReportConfig($this->projectIdWithConfigSet, $mockModule);
+
+    $reportSummary = array(
+        'reportId' => 42,
+        'title' => 'This is the title',
+        'strategy' => 'itemized',
+        'bucket-by' => null
+    );
+    $errors = $reportConfig->validate($reportSummary);
+    $this->assertTrue(in_array('bucket-by must have a value', $errors), 'validate should report missing value for bucket-by');
+  }
+
 }


### PR DESCRIPTION
This is the [dependency](https://github.com/cweiske/jsonmapper) I mentioned in stand up that could have been useful but needs at least PHP 5.6. I was thinking we could create a domain object `ReportSummary` that the request is mapped to to handle exceptions.

For now I added a `validate` function on `ReportConfig`. If there are errors it returns an array of those errors. `lib/settings.php` detects those errors and sends them to the UI and sets the response status to 400. The UI presents an error message.