### PR TITLE
REDDEV-568 itemized form

### DIFF
--- a/js-tests/components/ReportSummaryForm_test.js
+++ b/js-tests/components/ReportSummaryForm_test.js
@@ -53,6 +53,8 @@ describe('ReportSummaryForm.vue', () => {
   it('saves report summary on submit', (done) => {
     wrapper.vm.title = 'Report 2';
     wrapper.vm.reportId = 2;
+
+    wrapper.vm.strategy = 'total';
     wrapper.find('.btn-primary').trigger('click');
     wrapper.vm.savePromise.then(() => done());
     wrapper.vm.$nextTick(() => {
@@ -68,20 +70,23 @@ describe('ReportSummaryForm.vue', () => {
   it('validates form', () => {
     // Form rendered - no input
     wrapper.find('.btn-primary').trigger('click');
-    expect(wrapper.vm.errors.length).toEqual(2);
+    expect(wrapper.vm.errors.length).toEqual(3);
     expect(wrapper.vm.errors.includes('You must provide a title')).toBe(true);
     expect(wrapper.vm.errors.includes('You must select a report')).toBe(true);
+    expect(wrapper.vm.errors.includes('You must select a strategy')).toBe(true);
 
     // Only a report selected
     wrapper.vm.title = '';
     wrapper.vm.reportId = 42;
     wrapper.find('.btn-primary').trigger('click');
-    expect(wrapper.vm.errors.length).toEqual(1);
+    expect(wrapper.vm.errors.length).toEqual(2);
     expect(wrapper.vm.errors.includes('You must provide a title')).toBe(true);
+    expect(wrapper.vm.errors.includes('You must select a strategy')).toBe(true);
 
     // Only a title entered
     wrapper.vm.title = 'Some Title';
     wrapper.vm.reportId = null;
+    wrapper.vm.strategy = 'total';
     wrapper.find('.btn-primary').trigger('click');
     expect(wrapper.vm.errors.length).toEqual(1);
     expect(wrapper.vm.errors.includes('You must select a report')).toBe(true);
@@ -90,19 +95,28 @@ describe('ReportSummaryForm.vue', () => {
   it('retrieves report summary values from form', () => {
     wrapper.vm.reportId = 7;
     wrapper.vm.title = 'Report Title';
+    wrapper.vm.strategy = 'total';
+    wrapper.vm.bucketBy = 'bucketField';
     const reportSummary = wrapper.vm.reportSummary();
     expect(reportSummary.reportId).toEqual(7);
     expect(reportSummary.title).toEqual('Report Title');
     expect(reportSummary.strategy).toEqual('total');
+    expect(reportSummary.bucketBy).toEqual('bucketField');
   });
 
   it('cancel clears form', () => {
     wrapper.vm.reportId = 7;
     wrapper.vm.title = 'Report Title';
+    wrapper.vm.strategy = 'itemized';
+    wrapper.vm.bucketBy = 'someField';
     expect(wrapper.vm.reportId).toEqual(7);
     expect(wrapper.vm.title).toEqual('Report Title');
+    expect(wrapper.vm.strategy).toEqual('itemized');
+    expect(wrapper.vm.bucketBy).toEqual('someField');
     wrapper.vm.cancelForm();
     expect(wrapper.vm.reportId).toEqual(null);
     expect(wrapper.vm.title).toEqual('');
+    expect(wrapper.vm.strategy).toEqual(null);
+    expect(wrapper.vm.bucketBy).toEqual(null);
   });
 });

--- a/js-tests/components/ReportSummaryForm_test.js
+++ b/js-tests/components/ReportSummaryForm_test.js
@@ -54,7 +54,6 @@ describe('ReportSummaryForm.vue', () => {
   it('saves report summary on submit', (done) => {
     wrapper.vm.title = 'Report 2';
     wrapper.vm.reportId = 2;
-
     wrapper.vm.strategy = STRATEGY.TOTAL;
     wrapper.find('.btn-primary').trigger('click');
     wrapper.vm.savePromise.then(() => done());

--- a/js-tests/components/ReportSummaryForm_test.js
+++ b/js-tests/components/ReportSummaryForm_test.js
@@ -2,6 +2,7 @@ import uuid from 'uuid/v4';
 import { shallowMount } from '@vue/test-utils';
 
 import ReportSummaryForm from '@/components/ReportSummaryForm';
+import { messages } from '@/components/ReportSummaryForm';
 import { STRATEGY } from '@/report-strategy';
 
 function createProvideObject() {
@@ -71,9 +72,9 @@ describe('ReportSummaryForm.vue', () => {
     // Form rendered - no input
     wrapper.find('.btn-primary').trigger('click');
     expect(wrapper.vm.errors.length).toEqual(3);
-    expect(wrapper.vm.errors.includes('You must provide a title')).toBe(true);
-    expect(wrapper.vm.errors.includes('You must select a report')).toBe(true);
-    expect(wrapper.vm.errors.includes('You must select a strategy')).toBe(true);
+    expect(wrapper.vm.errors.includes(messages.titleRequired)).toBe(true);
+    expect(wrapper.vm.errors.includes(messages.reportRequired)).toBe(true);
+    expect(wrapper.vm.errors.includes(messages.strategyRequired)).toBe(true);
     expect(wrapper.findAll('#bucketBy').length).toBe(0);
 
     // Only a report selected
@@ -81,8 +82,8 @@ describe('ReportSummaryForm.vue', () => {
     wrapper.vm.reportId = 42;
     wrapper.find('.btn-primary').trigger('click');
     expect(wrapper.vm.errors.length).toEqual(2);
-    expect(wrapper.vm.errors.includes('You must provide a title')).toBe(true);
-    expect(wrapper.vm.errors.includes('You must select a strategy')).toBe(true);
+    expect(wrapper.vm.errors.includes(messages.titleRequired)).toBe(true);
+    expect(wrapper.vm.errors.includes(messages.strategyRequired)).toBe(true);
     expect(wrapper.findAll('#bucketBy').length).toBe(0);
 
     // Only a title entered
@@ -91,7 +92,7 @@ describe('ReportSummaryForm.vue', () => {
     wrapper.vm.strategy = STRATEGY.TOTAL;
     wrapper.find('.btn-primary').trigger('click');
     expect(wrapper.vm.errors.length).toEqual(1);
-    expect(wrapper.vm.errors.includes('You must select a report')).toBe(true);
+    expect(wrapper.vm.errors.includes(messages.reportRequired)).toBe(true);
     expect(wrapper.findAll('#bucketBy').length).toBe(0);
 
     // Require a bucketBy field on strategy='itemized'
@@ -100,7 +101,7 @@ describe('ReportSummaryForm.vue', () => {
     wrapper.vm.strategy = STRATEGY.ITEMIZED;
     wrapper.find('.btn-primary').trigger('click');
     expect(wrapper.vm.errors.length).toEqual(1);
-    expect(wrapper.vm.errors.includes(`You must select a field to group by when using the ${STRATEGY.ITEMIZED} strategy`)).toBe(true);
+    expect(wrapper.vm.errors.includes(messages.bucketByRequired)).toBe(true);
     expect(wrapper.findAll('#bucketBy').length).toBe(1);
   });
 

--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -2,6 +2,7 @@ import uuid from 'uuid/v4';
 import { shallowMount } from '@vue/test-utils';
 
 import ReportSummary from '@/components/ReportSummary';
+import { STRATEGY } from '@/report-strategy';
 
 function createProvideObject() {
   return {
@@ -23,7 +24,7 @@ describe('ReportSummary.vue', () => {
         propsData: {
           title: 'Sample Report Name',
           totalRecords: 101,
-          strategy: 'total'
+          strategy: STRATEGY.TOTAL
         }
       });
     });
@@ -42,7 +43,7 @@ describe('ReportSummary.vue', () => {
         propsData: {
           title: 'Sample Itemized Report Name',
           totalRecords: 6,
-          strategy: 'itemized',
+          strategy: STRATEGY.ITEMIZED,
           summaryData: [
             'Patient follow-up',
             'Patient withdrew consent',

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -14,6 +14,7 @@
 
 <script>
 import countBy from 'lodash/countBy';
+import { STRATEGY } from '../report-strategy';
 
 /**
  * Renders report summary.
@@ -30,7 +31,7 @@ export default {
 
   computed: {
     isItemized() {
-      return this.strategy === 'itemized';
+      return this.strategy === STRATEGY.ITEMIZED;
     },
 
     summaryCounts() {

--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -23,7 +23,7 @@
         </label>
       </div>
       <div class="form-group" v-if="isItemizedStrategy">
-        <label>Group By <input id="bucketBy" name="bucketBy" v-model="bucketBy" type="text" class="form-control"></label>
+        <label>Field to Group Results <input id="bucketBy" name="bucketBy" v-model="bucketBy" type="text" class="form-control"></label>
       </div>
       <button type="submit" class="btn btn-primary" @click="saveReportSummary">Submit</button>
       <a class="btn btn-link cancel" @click="cancelForm">Reset</a>

--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -15,6 +15,17 @@
           </select>
         </label>
       </div>
+      <div class="form-group">
+        <label>Strategy
+          <select id="strategy" name="strategy" v-model="strategy" class="form-control">
+            <option value="total">total</option>
+            <option value="itemized">itemized</option>
+          </select>
+        </label>
+      </div>
+      <div class="form-group">
+        <label>Bucket-by <input id="bucketby" name="bucketby" v-model="bucketby" type="text" class="form-control"></label>
+      </div>
       <button type="submit" class="btn btn-primary" @click="saveReportSummary">Submit</button>
       <a class="btn btn-link cancel" @click="cancelForm">Reset</a>
     </div>
@@ -90,7 +101,8 @@ export default {
       return {
         reportId: this.reportId,
         title: this.title,
-        strategy: 'total'
+        strategy: this.strategy,
+        "bucket-by": this.bucketby
       };
     },
 

--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -18,13 +18,12 @@
       <div class="form-group">
         <label>Strategy
           <select id="strategy" name="strategy" v-model="strategy" class="form-control">
-            <option value="total">total</option>
-            <option value="itemized">itemized</option>
+            <option v-for="strategy in strategies" :key="strategy" :value="strategy">{{ strategy }}</option>
           </select>
         </label>
       </div>
-      <div class="form-group">
-        <label>Bucket-by <input id="bucketby" name="bucketby" v-model="bucketby" type="text" class="form-control"></label>
+      <div class="form-group" v-if="isItemizedStrategy">
+        <label>Group By <input id="bucketBy" name="bucketBy" v-model="bucketBy" type="text" class="form-control"></label>
       </div>
       <button type="submit" class="btn btn-primary" @click="saveReportSummary">Submit</button>
       <a class="btn btn-link cancel" @click="cancelForm">Reset</a>
@@ -33,9 +32,13 @@
 </template>
 
 <script>
+import { STRATEGY } from '../report-strategy';
+
 const messages = {
   titleRequired: 'You must provide a title',
-  reportRequired: 'You must select a report'
+  reportRequired: 'You must select a report',
+  strategyRequired: 'You must select a strategy',
+  bucketByRequired: `You must select a field to group by when using the ${STRATEGY.ITEMIZED} strategy`
 };
 
 /**
@@ -49,6 +52,9 @@ export default {
     return {
       title: '',
       reportId: null,
+      strategy: null,
+      bucketBy: null,
+      strategies: Object.values(STRATEGY),
       reports: [],
       errors: []
     };
@@ -84,6 +90,8 @@ export default {
     clearForm() {
       this.title = '';
       this.reportId = null;
+      this.strategy = null;
+      this.bucketBy = null;
     },
 
     /**
@@ -102,7 +110,7 @@ export default {
         reportId: this.reportId,
         title: this.title,
         strategy: this.strategy,
-        "bucket-by": this.bucketby
+        bucketBy: this.bucketBy
       };
     },
 
@@ -116,6 +124,12 @@ export default {
       }
       if (this.reportId === null) {
         this.errors.push(messages.reportRequired);
+      }
+      if (this.strategy === null) {
+        this.errors.push(messages.strategyRequired);
+      }
+      if (this.strategy === STRATEGY.ITEMIZED && this.bucketBy === null) {
+        this.errors.push(messages.bucketByRequired);
       }
       return this.errors.length === 0;
     },
@@ -158,6 +172,13 @@ export default {
      */
     hasErrors() {
       return this.errors.length > 0;
+    },
+
+    /**
+     * @return true if the itemized strategy is selected
+     */
+    isItemizedStrategy() {
+      return this.strategy === STRATEGY.ITEMIZED;
     }
   }
 }

--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -34,7 +34,7 @@
 <script>
 import { STRATEGY } from '../report-strategy';
 
-const messages = {
+export const messages = {
   titleRequired: 'You must provide a title',
   reportRequired: 'You must select a report',
   strategyRequired: 'You must select a strategy',

--- a/js/report-strategy.js
+++ b/js/report-strategy.js
@@ -1,0 +1,4 @@
+export const STRATEGY = {
+  TOTAL: 'total',
+  ITEMIZED: 'itemized'
+};

--- a/lib/ReportConfig.php
+++ b/lib/ReportConfig.php
@@ -20,7 +20,7 @@ require_once(dirname(realpath(__FILE__)) . '/ReportStrategy.php');
  *     "reportId": 2,
  *     "title": "Report Title - With Itemized Counts",
  *     "strategy": "itemized",
- *     "bucket-by": "field_to_bucket_on"
+ *     "bucketBy": "field_to_bucket_on"
  *   }
  * ]
  * </code></pre>
@@ -75,12 +75,12 @@ class ReportConfig {
         $errors[] = 'Invalid strategy';
       } else {
         if ($reportSummary['strategy'] === ReportStrategy::ITEMIZED) {
-          if (array_key_exists('bucket-by', $reportSummary)) {
-            if (strlen(trim($reportSummary['bucket-by'])) === 0) {
-              $errors[] = "bucket-by must have a value";
+          if (array_key_exists('bucketBy', $reportSummary)) {
+            if (strlen(trim($reportSummary['bucketBy'])) === 0) {
+              $errors[] = "bucketBy must have a value";
             }
           } else {
-            $errors[] = 'Missing bucket-by field when using strategy ' . ReportStrategy::ITEMIZED;
+            $errors[] = 'Missing bucketBy field when using strategy ' . ReportStrategy::ITEMIZED;
           }
         }
       }

--- a/lib/ReportConfig.php
+++ b/lib/ReportConfig.php
@@ -75,9 +75,10 @@ class ReportConfig {
         $errors[] = 'Invalid strategy';
       } else {
         if ($reportSummary['strategy'] === ReportStrategy::ITEMIZED) {
-          if (array_key_exists('bucket-by', $reportSummary)
-              && strlen(trim($reportSummary['bucket-by'])) === 0) {
-            $errors[] = "bucket-by must have a value";
+          if (array_key_exists('bucket-by', $reportSummary)) {
+            if(strlen(trim($reportSummary['bucket-by'])) === 0) {
+              $errors[] = "bucket-by must have a value";
+            }
           } else {
             $errors[] = 'Missing bucket-by field when using strategy ' . ReportStrategy::ITEMIZED;
           }

--- a/lib/ReportConfigProcessor.php
+++ b/lib/ReportConfigProcessor.php
@@ -30,7 +30,7 @@ class ReportConfigProcessor {
      * @return Array of values for the field bucketBy
      */
     private function mapBucketData() {
-        $bucketBy = $this->summaryConfig['bucket-by'];
+        $bucketBy = $this->summaryConfig['bucketBy'];
         return array_map(function($record) use ($bucketBy) {
             return $record[$bucketBy];
         }, $this->report);

--- a/tests/MockAbstractExternalModule.php
+++ b/tests/MockAbstractExternalModule.php
@@ -16,7 +16,7 @@ class MockAbstractExternalModule {
             "name": "Report 2",
             "reportId": 202,
             "strategy": "itemized",
-            "bucket-by": "bucket_field"
+            "bucketBy": "bucket_field"
           },
           {
             "name": "Report 3",

--- a/tests/ReportConfigProcessorTest.php
+++ b/tests/ReportConfigProcessorTest.php
@@ -27,7 +27,7 @@ final class ReportConfigProcessorTest extends TestCase {
         'reportId' => 42,
         'title' => 'Test Report Summary',
         'strategy' => 'itemized',
-        'bucket-by' => 'dsp_stop_reason'
+        'bucketBy' => 'dsp_stop_reason'
     );
 
     /**

--- a/tests/ReportConfigTest.php
+++ b/tests/ReportConfigTest.php
@@ -61,7 +61,7 @@ final class ReportConfigTest extends TestCase {
 
     $this->assertEquals($config[0]['reportId'], 101);
     $this->assertEquals($config[1]['strategy'], 'itemized');
-    $this->assertEquals($config[1]['bucket-by'], 'bucket_field');
+    $this->assertEquals($config[1]['bucketBy'], 'bucket_field');
     $this->assertEquals($config[2]['name'], 'Report 3');
   }
 
@@ -115,7 +115,7 @@ final class ReportConfigTest extends TestCase {
         'strategy' => 'itemized'
     );
     $errors = $reportConfig->validate($reportSummary);
-    $this->assertTrue(in_array('Missing bucket-by field when using strategy itemized', $errors), 'validate should report missing field bucket-by');
+    $this->assertTrue(in_array('Missing bucketBy field when using strategy itemized', $errors), 'validate should report missing field bucketBy');
   }
 
   public function testValidateMissingBucketByValue() {
@@ -126,10 +126,10 @@ final class ReportConfigTest extends TestCase {
         'reportId' => 42,
         'title' => 'This is the title',
         'strategy' => 'itemized',
-        'bucket-by' => null
+        'bucketBy' => null
     );
     $errors = $reportConfig->validate($reportSummary);
-    $this->assertTrue(in_array('bucket-by must have a value', $errors), 'validate should report missing value for bucket-by');
+    $this->assertTrue(in_array('bucketBy must have a value', $errors), 'validate should report missing value for bucketBy');
   }
 
 }


### PR DESCRIPTION
Add fields `strategy` and `bucketBy` to the form for creating an itemized count.

Use constants for report strategy everywhere. Similarly use messages constants in unit tests.

Rename `bucket-by` `bucketBy` everywhere.

If strategy is total then the group by field is optional:

![screen shot 2018-11-01 at 14 03 14](https://user-images.githubusercontent.com/273863/47879898-0835f700-dddf-11e8-9901-2399027beea1.png)

If strategy is itemized then you must enter a column to group by. TODO: dynamically create a drop-down of values for fields to group by.

![screen shot 2018-11-01 at 14 03 27](https://user-images.githubusercontent.com/273863/47879933-1c79f400-dddf-11e8-85de-e0832eaf885d.png)

An example of an itemized count:

![screen shot 2018-11-01 at 14 03 42](https://user-images.githubusercontent.com/273863/47879988-49c6a200-dddf-11e8-88c5-cc1400cf87f9.png)