### PR TITLE
REDDEV-587 expose grouped by field

### DIFF
--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -5,6 +5,11 @@ import { STRATEGY } from '@/report-strategy';
 import { MISSING } from '@/constants';
 import shuffle from 'lodash/shuffle';
 
+const selectors = {
+  metadata: '.summary-metadata li',
+  counts: '[data-description="itemized-counts"] li'
+};
+
 describe('ReportSummary.vue', () => {
   describe('For total strategy', () => {
     let wrapper;
@@ -22,7 +27,10 @@ describe('ReportSummary.vue', () => {
 
     it('renders report summary', () => {
       const reportName = wrapper.find('h3');
-      expect(reportName.text()).toBe('101 - Sample Report Name');
+      expect(reportName.text()).toBe('Sample Report Name');
+      const metadata = wrapper.findAll(selectors.metadata);
+      expect(metadata.length).toBe(1);
+      expect(metadata.at(0).text()).toBe('Total Count: 101');
     });
   });
 
@@ -36,6 +44,7 @@ describe('ReportSummary.vue', () => {
           title: 'Sample Itemized Report Name',
           totalRecords: 6,
           strategy: STRATEGY.ITEMIZED,
+          bucketByLabel: 'Field Label',
           summaryData: [
             'Patient follow-up',
             'Patient withdrew consent',
@@ -50,14 +59,24 @@ describe('ReportSummary.vue', () => {
 
     it('renders report summary with itemized counts', (done) => {
       const reportName = wrapper.find('h3');
-
-      expect(reportName.text()).toBe('6 - Sample Itemized Report Name');
+      expect(reportName.text()).toBe('Sample Itemized Report Name');
 
       wrapper.vm.$nextTick(() => {
-        expect(wrapper.findAll('li').length).toEqual(3);
-        expect(wrapper.findAll('li').at(0).text()).toEqual('3 - Patient follow-up');
-        expect(wrapper.findAll('li').at(1).text()).toEqual('2 - Patient withdrew consent');
-        expect(wrapper.findAll('li').at(2).text()).toEqual('1 - Perceived drug side effects');
+        const li = wrapper.findAll(selectors.counts);
+        expect(li.length).toEqual(3);
+        expect(li.at(0).text()).toEqual('3 - Patient follow-up');
+        expect(li.at(1).text()).toEqual('2 - Patient withdrew consent');
+        expect(li.at(2).text()).toEqual('1 - Perceived drug side effects');
+        done();
+      });
+    });
+
+    it('renders a metadata section', (done) => {
+      wrapper.vm.$nextTick(() => {
+        const metadata = wrapper.findAll(selectors.metadata);
+        expect(metadata.length).toBe(2);
+        expect(metadata.at(0).text()).toBe('Total Count: 6');
+        expect(metadata.at(1).text()).toBe('Grouped By: Field Label');
         done();
       });
     });
@@ -113,7 +132,7 @@ describe('ReportSummary.vue', () => {
       wrapper.vm.$nextTick(() => {
         expect(wrapper.vm.hasMissingValue).toBe(true);
 
-        const li = wrapper.findAll('li');
+        const li = wrapper.findAll(selectors.counts);
         expect(li.length).toBe(5);
         expect(li.at(4).text()).toBe(`3 - ${MISSING}`);
         done();
@@ -136,7 +155,7 @@ describe('ReportSummary.vue', () => {
       const wrapper = shallowMount(ReportSummary, { propsData: propsData });
 
       wrapper.vm.$nextTick(() => {
-        const li = wrapper.findAll('li');
+        const li = wrapper.findAll(selectors.counts);
         expect(li.length).toBe(8);
 
         // Count in descending order

--- a/js/components/ConsortReport.vue
+++ b/js/components/ConsortReport.vue
@@ -32,6 +32,7 @@
                        :index="i"
                        :title="summary.title"
                        :strategy="summary.strategy"
+                       :bucketByLabel="summary.bucketByLabel"
                        :summaryData="summary.data"
                        :total-records="summary.totalRecords"
                        @deleteSummary="deleteReportSummary" />

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -2,11 +2,15 @@
   <div class="card mb-3 report-summary" :data-index="index">
     <div class="card-body">
       <div class="container">
-        <h3 class="card-title mb-0">{{ totalRecords }} - {{ title }}</h3>
-        <div class="summary-controls mb-3">
+        <h3 class="card-title mb-1">{{ title }}</h3>
+        <div class="summary-controls mb-1">
           <a class="delete" v-if="canDelete" @click="deleteSummary">Delete <i class="far fa-trash-alt"></i></a>
         </div>
-        <ul v-if="isItemized" class="list-unstyled">
+        <ul class="summary-metadata lead list-unstyled mb-0">
+          <li>Total Count: {{ totalRecords }}</li>
+          <li v-if="isItemized" class="mt-0">Grouped By: {{bucketByLabel}}</li>
+        </ul>
+        <ul v-if="isItemized" class="list-unstyled mt-3 mb-0" data-description="itemized-counts">
           <li v-for="summary in sortedSummaryCounts" :key="summary.label">{{ summary.count }} - {{ summary.label }}</li>
         </ul>
       </div>
@@ -32,6 +36,7 @@ export default {
     title: String,
     totalRecords: Number,
     strategy: String,
+    bucketByLabel: String,
     summaryData: Array
   },
 

--- a/lib/DataDictionary.php
+++ b/lib/DataDictionary.php
@@ -1,0 +1,22 @@
+<?php
+namespace Octri\ConsortReport;
+
+/**
+ * A class for working with a project's data dictionary.
+ */
+class DataDictionary {
+
+    private $dictionary;
+
+    /**
+     * @param Array dictionary Data dictionary as returned by `REDCap::getDataDictionary('array')`
+     */
+    public function __construct($dictionary) {
+        $this->dictionary = $dictionary;
+    }
+
+    public function getFieldLabel($fieldName) {
+        return $this->dictionary[$fieldName]['field_label'];
+    }
+
+}

--- a/lib/DataDictionary.php
+++ b/lib/DataDictionary.php
@@ -12,6 +12,7 @@ class DataDictionary {
      * @param Array dictionary Data dictionary as returned by `REDCap::getDataDictionary('array')`
      */
     public function __construct($dictionary) {
+        assert(isset($dictionary), '$dictionary is required.');
         $this->dictionary = $dictionary;
     }
 

--- a/lib/SummaryUIProcessor.php
+++ b/lib/SummaryUIProcessor.php
@@ -4,27 +4,30 @@ namespace Octri\ConsortReport;
 require_once(dirname(realpath(__FILE__)) . '/ReportStrategy.php');
 
 /**
- * A class for processing report configuration. Handles updating report summary
- * configuration for the defined strategy.
+ * A class for processing report configuration to produce data suitable for UI
+ * rendering.
  */
-class ReportConfigProcessor {
+class SummaryUIProcessor {
 
-    private $report;
     private $summaryConfig;
+    private $report;
+    private $dataDictionary;
 
     /**
-     * @param Array report The report data.
-     * @param Array summaryConfig The configuration for the report data. Used to
-     * build the <code>ReportSummary</code>.
+     * @param Array summaryConfig An entry in the array of report config
+     *   persisted to the database.
+     * @param String report The report data as returned by `REDCap::getReport`.
+     * @param Number dataDictionary An instance of `DataDictionary`.
      */
-    public function __construct($report, $summaryConfig) {
-        $this->report = $report;
+    public function __construct($summaryConfig, $report, $dataDictionary) {
         $this->summaryConfig = $summaryConfig;
+        $this->report = $report;
+        $this->dataDictionary = $dataDictionary;
     }
 
     /**
      * Returns a flattened array containing only the values for the
-     * <code>bucketBy</code> field.
+     * <code>bucketBy</code> field. Used by the UI for grouping itemized counts.
      * @param String bucketBy The field name to bucket data by.
      * @param Array data The report data.
      * @return Array of values for the field bucketBy
@@ -45,13 +48,18 @@ class ReportConfigProcessor {
     }
 
     /**
-     * Update the summary configuration. Include data for itemized counts if
-     * defined in the configuration as well as the total number of records.
-     * @return The updated summary configuration.
+     * Gets summary config used by the UI for rendering each report 
+     * summary (count). If an itemized count is required, include the field
+     * label for the field grouped on as well as data used to render itemized
+     * counts. The UI handles grouping the data.
+     * @return Summary config for rendering in the UI.
      */
     public function summaryConfig() {
         $this->summaryConfig['totalRecords'] = $this->totalRecords();
         if ($this->summaryConfig['strategy'] === ReportStrategy::ITEMIZED) {
+            $bucketBy = $this->summaryConfig['bucketBy'];
+            $bucketByLabel = $this->dataDictionary->getFieldLabel($bucketBy);
+            $this->summaryConfig['bucketByLabel'] = $bucketByLabel;
             $this->summaryConfig['data'] = $this->mapBucketData();
         }
         return $this->summaryConfig;

--- a/lib/SummaryUIProcessor.php
+++ b/lib/SummaryUIProcessor.php
@@ -20,6 +20,9 @@ class SummaryUIProcessor {
      * @param Number dataDictionary An instance of `DataDictionary`.
      */
     public function __construct($summaryConfig, $report, $dataDictionary) {
+        assert(isset($summaryConfig), '$summaryConfig is required.');
+        assert(isset($report), '$report is required.');
+        assert(isset($dataDictionary), '$dataDictionary is required.');
         $this->summaryConfig = $summaryConfig;
         $this->report = $report;
         $this->dataDictionary = $dataDictionary;

--- a/lib/consort-report.css
+++ b/lib/consort-report.css
@@ -2,3 +2,7 @@
   color: #c30 ! important;
   cursor: pointer;
 }
+
+.summary-metadata {
+  font-size: 0.9rem;
+}

--- a/lib/data.php
+++ b/lib/data.php
@@ -13,7 +13,7 @@ header('Content-Type: application/json');
 require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 require_once(dirname(realpath(__FILE__)) . '/ReportConfig.php');
 require_once(dirname(realpath(__FILE__)) . '/DataDictionary.php');
-require_once(dirname(realpath(__FILE__)) . '/ReportConfigProcessor.php');
+require_once(dirname(realpath(__FILE__)) . '/SummaryUIProcessor.php');
 
 if (isset($_GET['action'])) {
     if ($_GET['action'] === 'getReports') {
@@ -72,10 +72,8 @@ if (isset($_GET['action'])) {
     $returnArray = array();
     foreach ($config as $summaryConfig) {
         $report = json_decode(\REDCap::getReport($summaryConfig['reportId'], 'json', true /* export labels */), true);
-        $reportProcessor = new ReportConfigProcessor($report, $summaryConfig);
-        $summary = $reportProcessor->summaryConfig();
-        $summary['bucketByLabel'] = $dataDictionary->getFieldLabel($summary['bucketBy']);
-        $returnArray[] = $summary;
+        $reportProcessor = new SummaryUIProcessor($summaryConfig, $report, $dataDictionary);
+        $returnArray[] = $reportProcessor->summaryConfig();
     }
 
     exit(json_encode($returnArray));

--- a/lib/data.php
+++ b/lib/data.php
@@ -12,6 +12,7 @@ header('Content-Type: application/json');
 // Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
 require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 require_once(dirname(realpath(__FILE__)) . '/ReportConfig.php');
+require_once(dirname(realpath(__FILE__)) . '/DataDictionary.php');
 require_once(dirname(realpath(__FILE__)) . '/ReportConfigProcessor.php');
 
 if (isset($_GET['action'])) {
@@ -65,12 +66,16 @@ if (isset($_GET['action'])) {
         exit(json_encode(array()));
     }
 
+    $dataDictionary = new DataDictionary(\REDCap::getDataDictionary('array'));
+
     // Default action, get report config
     $returnArray = array();
     foreach ($config as $summaryConfig) {
         $report = json_decode(\REDCap::getReport($summaryConfig['reportId'], 'json', true /* export labels */), true);
         $reportProcessor = new ReportConfigProcessor($report, $summaryConfig);
-        $returnArray[] = $reportProcessor->summaryConfig();
+        $summary = $reportProcessor->summaryConfig();
+        $summary['bucketByLabel'] = $dataDictionary->getFieldLabel($summary['bucketBy']);
+        $returnArray[] = $summary;
     }
 
     exit(json_encode($returnArray));

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -12,6 +12,7 @@ header('Content-Type: application/json');
 require_once(dirname(realpath(__FILE__)) . '/../../../redcap_connect.php');
 require_once(dirname(realpath(__FILE__)) . '/ReportConfig.php');
 require_once(dirname(realpath(__FILE__)) . '/ReportConfigProcessor.php');
+require_once(dirname(realpath(__FILE__)) . '/DataDictionary.php');
 
 if (isset($_GET['action'])) {
     $requestBody = trim(file_get_contents('php://input'));
@@ -29,7 +30,10 @@ if (isset($_GET['action'])) {
                 $report = json_decode(\REDCap::getReport($reportSummary['reportSummary']['reportId'], 'json', true /* export labels */), true);
                 $reportProcessor = new ReportConfigProcessor($report, $reportSummary['reportSummary']);
 
-                exit(json_encode(array($reportProcessor->summaryConfig())));
+                $summaryConfig = $reportProcessor->summaryConfig();
+                $dataDictionary = new DataDictionary(\REDCap::getDataDictionary('array'));
+                $summaryConfig['bucketByLabel'] = $dataDictionary->getFieldLabel($summaryConfig['field_name']);
+                exit(json_encode(array($summaryConfig)));
             }
 
         } else if ($_GET['action'] === 'saveReportSummaries') {

--- a/test_bootstrap.php
+++ b/test_bootstrap.php
@@ -6,4 +6,5 @@
  */
 require_once('lib/ReportConfig.php');
 require_once('lib/ReportConfigProcessor.php');
+require_once('lib/DataDictionary.php');
 

--- a/test_bootstrap.php
+++ b/test_bootstrap.php
@@ -5,6 +5,6 @@
  * @see phpunit.xml
  */
 require_once('lib/ReportConfig.php');
-require_once('lib/ReportConfigProcessor.php');
+require_once('lib/SummaryUIProcessor.php');
 require_once('lib/DataDictionary.php');
 

--- a/tests/DataDictionaryTest.php
+++ b/tests/DataDictionaryTest.php
@@ -1,0 +1,33 @@
+<?php
+use Octri\ConsortReport\DataDictionary,
+    PHPUnit\Framework\TestCase;
+
+/**
+ * @covers DataDictionary
+ */
+final class DataDictionaryTest extends TestCase {
+
+  public function testGetFieldName() {
+    $mockDictionary = array(
+      'screen_id' => array(
+        "field_name" => "screen_id",
+        "form_name" => "screening_id",
+        "field_label" => "Screening Id"
+      ),
+      'dsp_stop_reason' => array(
+        "field_name" => "dsp_stop_reason",
+        "form_name" => "subject_data",
+        "field_label" => "Stop Reason"
+      ),
+      'another_field' => array(
+        "field_name" => "another_field",
+        "form_name" => "another_form",
+        "field_label" => "Another Field"
+      )
+    );
+    $dataDictionary = new DataDictionary($mockDictionary);
+    $this->assertEquals('Stop Reason', $dataDictionary->getFieldLabel('dsp_stop_reason'));
+    $this->assertEquals('Another Field', $dataDictionary->getFieldLabel('another_field'));
+  }
+
+}

--- a/tests/DataDictionaryTest.php
+++ b/tests/DataDictionaryTest.php
@@ -10,19 +10,19 @@ final class DataDictionaryTest extends TestCase {
   public function testGetFieldName() {
     $mockDictionary = array(
       'screen_id' => array(
-        "field_name" => "screen_id",
-        "form_name" => "screening_id",
-        "field_label" => "Screening Id"
+        'field_name' => 'screen_id',
+        'form_name' => 'screening_id',
+        'field_label' => 'Screening Id'
       ),
       'dsp_stop_reason' => array(
-        "field_name" => "dsp_stop_reason",
-        "form_name" => "subject_data",
-        "field_label" => "Stop Reason"
+        'field_name' => 'dsp_stop_reason',
+        'form_name' => 'subject_data',
+        'field_label' => 'Stop Reason'
       ),
       'another_field' => array(
-        "field_name" => "another_field",
-        "form_name" => "another_form",
-        "field_label" => "Another Field"
+        'field_name' => 'another_field',
+        'form_name' => 'another_form',
+        'field_label' => 'Another Field'
       )
     );
     $dataDictionary = new DataDictionary($mockDictionary);

--- a/tests/SummaryUIProcessorTest.php
+++ b/tests/SummaryUIProcessorTest.php
@@ -1,11 +1,12 @@
 <?php
-use Octri\ConsortReport\ReportConfigProcessor,
+use Octri\ConsortReport\SummaryUIProcessor,
+    Octri\ConsortReport\DataDictionary,
     PHPUnit\Framework\TestCase;
 
 /**
- * @covers ReportConfigProcessor
+ * @covers SummaryUIProcessor
  */
-final class ReportConfigProcessorTest extends TestCase {
+final class SummaryUIProcessorTest extends TestCase {
 
     /**
      * Report as returned by REDCap.
@@ -40,11 +41,41 @@ final class ReportConfigProcessorTest extends TestCase {
         'strategy' => 'total'
     );
 
+    /**
+     * Mock array data returned by `REDCap::getDataDictionary('array')`
+     */
+    private $mockDictionaryData = array(
+      'screen_id' => array(
+        'field_name' => 'screen_id',
+        'form_name' => 'screening_id',
+        'field_label' => 'Screening Id'
+      ),
+      'dsp_stop_reason' => array(
+        'field_name' => 'dsp_stop_reason',
+        'form_name' => 'subject_data',
+        'field_label' => 'Stop Reason'
+      ),
+      'another_field' => array(
+        'field_name' => 'another_field',
+        'form_name' => 'another_form',
+        'field_label' => 'Another Field'
+      )
+    );
+
+    /**
+     * Instance of lib/DataDictionary.php
+     */
+    private $mockDataDictionary;
+
+    public function setUp() {
+        $this->dataDictionary = new DataDictionary($this->mockDictionaryData);
+    }
+
     public function testReportSummaryWithOnlyTotalCount() {
         $expectedSummaryConfig = array_merge($this->mockTotalSummaryConfig,
             array("totalRecords" => 6));
 
-        $reportProcessor = new ReportConfigProcessor($this->mockReport, $this->mockTotalSummaryConfig);
+        $reportProcessor = new SummaryUIProcessor($this->mockTotalSummaryConfig, $this->mockReport, $this->mockDataDictionary);
 
         $processedSummaryConfig = $reportProcessor->summaryConfig();
 
@@ -66,7 +97,7 @@ final class ReportConfigProcessorTest extends TestCase {
             "totalRecords" => 6
         ));
 
-        $reportProcessor = new ReportConfigProcessor($this->mockReport, $this->mockItemizedSummaryConfig);
+        $reportProcessor = new SummaryUIProcessor($this->mockItemizedSummaryConfig, $this->mockReport, $this->mockDataDictionary);
 
         $processedSummaryConfig = $reportProcessor->summaryConfig();
 

--- a/tests/SummaryUIProcessorTest.php
+++ b/tests/SummaryUIProcessorTest.php
@@ -68,7 +68,7 @@ final class SummaryUIProcessorTest extends TestCase {
     private $mockDataDictionary;
 
     public function setUp() {
-        $this->dataDictionary = new DataDictionary($this->mockDictionaryData);
+        $this->mockDataDictionary = new DataDictionary($this->mockDictionaryData);
     }
 
     public function testReportSummaryWithOnlyTotalCount() {


### PR DESCRIPTION
Refactored UI. Moved total count from summary header underneath the summary controls (delete, edit, ...).

Count is labeled 'Total Count' and the field grouped by is exposed and labeled 'Grouped By'.

Field label pulled from the data dictionary and inserted into each report summary config used to render counts.

<img width="567" alt="screen shot 2018-11-16 at 15 12 07" src="https://user-images.githubusercontent.com/273863/48651979-188acc00-e9b2-11e8-98b8-76b8a18bc94d.png">