### PR TITLE
Fix Missing URL Assertion

### DIFF
--- a/js/services/data-service.js
+++ b/js/services/data-service.js
@@ -3,8 +3,7 @@ import axios from 'axios';
 
 export const ENDPOINTS = {
   REPORT_DATA: 'lib/data.php',
-  REPORT_CONFIG: 'lib/settings.php',
-  DATA_DICTIONARY: 'lib/data-dictionary.php'
+  REPORT_CONFIG: 'lib/settings.php'
 };
 
 /**
@@ -25,7 +24,6 @@ export default function createDataService(assetUrls) {
   return {
     reportDataUrl: assetUrls[ENDPOINTS.REPORT_DATA],
     reportConfigUrl: assetUrls[ENDPOINTS.REPORT_CONFIG],
-    dataDictionaryUrl: assetUrls[ENDPOINTS.DATA_DICTIONARY],
 
     /**
      * Extracts data returned by the request.


### PR DESCRIPTION
Fix assertion error thrown when creating the data service. The service is still asserting that a URL must be provided for `lib/data-dictionary.php`, which was deleted in commit 0446370.