### PR TITLE
Use async/await

### DIFF
--- a/js-tests/components/ConsortReport_test.js
+++ b/js-tests/components/ConsortReport_test.js
@@ -51,7 +51,7 @@ describe('ConsortReport.vue', () => {
   let mockProvide, wrapper;
 
   describe('With report summaries', () => {
-    beforeEach((done) => {
+    beforeEach(async () => {
       mockProvide = provideWithSummaries();
       spyOn(mockProvide.dataService, 'fetchReportSummary').and.callThrough();
       spyOn(mockProvide.dataService, 'getReports').and.callThrough();
@@ -61,7 +61,7 @@ describe('ConsortReport.vue', () => {
         provide: mockProvide
       });
 
-      wrapper.vm.configPromise.then(() => done());
+      await wrapper.vm.configPromise;
     });
 
     it('requests report summary when mounted', () => {
@@ -87,7 +87,7 @@ describe('ConsortReport.vue', () => {
   });
 
   describe('Without report summaries', () => {
-    beforeEach((done) => {
+    beforeEach(async () => {
       mockProvide = provideWithoutSummaries();
       spyOn(mockProvide.dataService, 'fetchReportSummary').and.callThrough();
 
@@ -95,7 +95,7 @@ describe('ConsortReport.vue', () => {
         provide: mockProvide
       });
 
-      wrapper.vm.configPromise.then(() => done());
+      await wrapper.vm.configPromise;
     });
 
     it('shows create a report button - all else hidden', () => {
@@ -116,7 +116,7 @@ describe('ConsortReport.vue', () => {
   describe('drag and drop', () => {
     let mockReportSummaries;
 
-    beforeEach((done) => {
+    beforeEach(async () => {
       mockReportSummaries = [
         {
           id: 'one-id',
@@ -159,7 +159,7 @@ describe('ConsortReport.vue', () => {
         provide: mockProvide
       });
 
-      wrapper.vm.configPromise.then(() => done());
+      await wrapper.vm.configPromise;
     });
 
     it('default dnd state', () => {

--- a/js-tests/components/ReportSummaryForm_test.js
+++ b/js-tests/components/ReportSummaryForm_test.js
@@ -38,7 +38,7 @@ function createProvideObject() {
 describe('ReportSummaryForm.vue', () => {
   let mockProvide, wrapper;
 
-  beforeEach((done) => {
+  beforeEach(async () => {
     mockProvide = createProvideObject();
 
     spyOn(mockProvide.dataService, 'getReports').and.callThrough();
@@ -48,7 +48,7 @@ describe('ReportSummaryForm.vue', () => {
       provide: mockProvide
     });
 
-    wrapper.vm.reportPromise.then(() => done());
+    await wrapper.vm.reportPromise;
   });
 
   describe('Report Summary Form', () => {
@@ -63,12 +63,10 @@ describe('ReportSummaryForm.vue', () => {
 
     it('renders report drop-down', () => {
       expect(wrapper.findAll('#reportId').length).toEqual(1);
-      wrapper.vm.$nextTick(() => {
-        const options = wrapper.findAll('#reportId option');
-        expect(options.length).toEqual(3);
-        expect(options.at(1).attributes().value).toEqual('2');
-        expect(options.at(1).text()).toEqual('Report 2');
-      });
+      const options = wrapper.findAll('#reportId option');
+      expect(options.length).toEqual(3);
+      expect(options.at(1).attributes().value).toEqual('2');
+      expect(options.at(1).text()).toEqual('Report 2');
     });
 
     it('makes drop-down with group by values visible when itemized strategy selected', () => {
@@ -102,22 +100,22 @@ describe('ReportSummaryForm.vue', () => {
     });
   });
 
-  it('saves report summary on submit', (done) => {
+  it('saves report summary on submit', async () => {
     wrapper.vm.title = 'Report 2';
     wrapper.vm.reportId = 2;
     wrapper.vm.strategy = STRATEGY.TOTAL;
     wrapper.find('.btn-primary').trigger('click');
-    wrapper.vm.savePromise.then(() => done());
-    wrapper.vm.$nextTick(() => {
-      const reportSummary = wrapper.emitted().reportSummary;
-      expect(reportSummary[0].length).toEqual(1);
 
-      const summaryObject = reportSummary[0][0];
-      expect(summaryObject.id).toMatch(uuidPattern);
-      expect(summaryObject.reportId).toEqual(2);
-      expect(summaryObject.title).toEqual('Report 2');
-      expect(summaryObject.strategy).toEqual(STRATEGY.TOTAL);
-    });
+    await wrapper.vm.savePromise;
+
+    const reportSummary = wrapper.emitted().reportSummary;
+    expect(reportSummary[0].length).toEqual(1);
+
+    const summaryObject = reportSummary[0][0];
+    expect(summaryObject.id).toMatch(uuidPattern);
+    expect(summaryObject.reportId).toEqual(2);
+    expect(summaryObject.title).toEqual('Report 2');
+    expect(summaryObject.strategy).toEqual(STRATEGY.TOTAL);
   });
 
   it('validates form', () => {
@@ -254,25 +252,25 @@ describe('ReportSummaryForm.vue', () => {
     expect(wrapper.vm.errors.includes(messages.bucketByRequired)).toEqual(true);
   });
 
-  it('hides form title', (done) => {
+  it('hides form title', async () => {
     wrapper = shallowMount(ReportSummaryForm, {
       provide: createProvideObject(),
       propsData: {
         hideFormTitle: true
       }
     });
-    wrapper.vm.reportPromise.then(() => done());
+    await wrapper.vm.reportPromise;
     expect(wrapper.findAll('.card-header').length).toEqual(0);
   });
 
-  it('shows form title', (done) => {
+  it('shows form title', async () => {
     wrapper = shallowMount(ReportSummaryForm, {
       provide: createProvideObject(),
       propsData: {
         hideFormTitle: false
       }
     });
-    wrapper.vm.reportPromise.then(() => done());
+    await wrapper.vm.reportPromise;
     expect(wrapper.findAll('.card-header').length).toEqual(1);
   });
 });

--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -57,47 +57,35 @@ describe('ReportSummary.vue', () => {
       });
     });
 
-    it('renders report summary with itemized counts', (done) => {
+    it('renders report summary with itemized counts', () => {
       const reportName = wrapper.find('h3');
       expect(reportName.text()).toEqual('Sample Itemized Report Name');
 
-      wrapper.vm.$nextTick(() => {
-        const li = wrapper.findAll(selectors.counts);
-        expect(li.length).toEqual(3);
-        expect(li.at(0).text()).toEqual('3 - Patient follow-up');
-        expect(li.at(1).text()).toEqual('2 - Patient withdrew consent');
-        expect(li.at(2).text()).toEqual('1 - Perceived drug side effects');
-        done();
-      });
+      const li = wrapper.findAll(selectors.counts);
+      expect(li.length).toEqual(3);
+      expect(li.at(0).text()).toEqual('3 - Patient follow-up');
+      expect(li.at(1).text()).toEqual('2 - Patient withdrew consent');
+      expect(li.at(2).text()).toEqual('1 - Perceived drug side effects');
     });
 
-    it('renders a metadata section', (done) => {
-      wrapper.vm.$nextTick(() => {
-        const metadata = wrapper.findAll(selectors.metadata);
-        expect(metadata.length).toEqual(2);
-        expect(metadata.at(0).text()).toEqual('Total Count: 6');
-        expect(metadata.at(1).text()).toEqual('Grouped By: Field Label');
-        done();
-      });
+    it('renders a metadata section', () => {
+      const metadata = wrapper.findAll(selectors.metadata);
+      expect(metadata.length).toEqual(2);
+      expect(metadata.at(0).text()).toEqual('Total Count: 6');
+      expect(metadata.at(1).text()).toEqual('Grouped By: Field Label');
     });
 
-    it('emits deleteSummary event', (done) => {
-      wrapper.vm.$nextTick(() => {
-        spyOn(window, 'confirm').and.returnValue(true);
-        wrapper.find('.delete').trigger('click');
-        expect(wrapper.emitted('deleteSummary')).toBeTruthy();
-        expect(wrapper.emitted('deleteSummary')[0]).toBeTruthy();
-        done();
-      });
+    it('emits deleteSummary event', () => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      wrapper.find('.delete').trigger('click');
+      expect(wrapper.emitted('deleteSummary')).toBeTruthy();
+      expect(wrapper.emitted('deleteSummary')[0]).toBeTruthy();
     });
 
-    it('does not emit deleteSummary event if canceled', (done) => {
-      wrapper.vm.$nextTick(() => {
-        spyOn(window, 'confirm').and.returnValue(false);
-        wrapper.find('.delete').trigger('click');
-        expect(wrapper.emitted('deleteSummary')).toBeFalsy();
-        done();
-      });
+    it('does not emit deleteSummary event if canceled', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      wrapper.find('.delete').trigger('click');
+      expect(wrapper.emitted('deleteSummary')).toBeFalsy();
     });
   });
 
@@ -110,7 +98,7 @@ describe('ReportSummary.vue', () => {
       summaryData: []
     };
 
-    it('handles missing values', (done) => {
+    it('handles missing values', () => {
       propsData.summaryData = [
         'Patient follow-up',
         '42',
@@ -128,18 +116,14 @@ describe('ReportSummary.vue', () => {
       ];
 
       const wrapper = shallowMount(ReportSummary, { propsData: propsData });
+      expect(wrapper.vm.hasMissingValue).toEqual(true);
 
-      wrapper.vm.$nextTick(() => {
-        expect(wrapper.vm.hasMissingValue).toEqual(true);
-
-        const li = wrapper.findAll(selectors.counts);
-        expect(li.length).toEqual(5);
-        expect(li.at(4).text()).toEqual(`3 - ${MISSING}`);
-        done();
-      });
+      const li = wrapper.findAll(selectors.counts);
+      expect(li.length).toEqual(5);
+      expect(li.at(4).text()).toEqual(`3 - ${MISSING}`);
     });
 
-    it('orders counts', (done) => {
+    it('orders counts', () => {
       propsData.summaryData = shuffle([
         ...new Array(3).fill('January'),
         ...new Array(2).fill('Afakemonth'),
@@ -154,25 +138,22 @@ describe('ReportSummary.vue', () => {
 
       const wrapper = shallowMount(ReportSummary, { propsData: propsData });
 
-      wrapper.vm.$nextTick(() => {
-        const li = wrapper.findAll(selectors.counts);
-        expect(li.length).toEqual(8);
+      const li = wrapper.findAll(selectors.counts);
+      expect(li.length).toEqual(8);
 
-        // Count in descending order
-        expect(li.at(0).text()).toEqual('15 - May');
-        expect(li.at(1).text()).toEqual('10 - February');
-        expect(li.at(2).text()).toEqual('7 - March');
-        expect(li.at(3).text()).toEqual('3 - January');
+      // Count in descending order
+      expect(li.at(0).text()).toEqual('15 - May');
+      expect(li.at(1).text()).toEqual('10 - February');
+      expect(li.at(2).text()).toEqual('7 - March');
+      expect(li.at(3).text()).toEqual('3 - January');
 
-        // Label is ascending when the count is the same
-        expect(li.at(4).text()).toEqual('2 - Afakemonth');
-        expect(li.at(5).text()).toEqual('2 - April');
-        expect(li.at(6).text()).toEqual('2 - August');
+      // Label is ascending when the count is the same
+      expect(li.at(4).text()).toEqual('2 - Afakemonth');
+      expect(li.at(5).text()).toEqual('2 - April');
+      expect(li.at(6).text()).toEqual('2 - August');
 
-        // Missing is always the last count
-        expect(li.at(7).text()).toEqual(`42 - ${MISSING}`);
-        done();
-      });
+      // Missing is always the last count
+      expect(li.at(7).text()).toEqual(`42 - ${MISSING}`);
     });
   });
 


### PR DESCRIPTION
Use `async` and `await` to simplify tests with promises. I found that this made timing more consistent and allowed the elimination of uses of `$nextTick` in tests.